### PR TITLE
feat: resolve components in render functions

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -960,7 +960,7 @@ class AstSerializer {
 			if(options.currentTransformTypes && options.currentTransformTypes.length > 0) {
 				c = await this.transformContent(node.value, options.currentTransformTypes, node, this.components[options.closestParentComponent], options);
 
-				// only reprocess text nodes in a <* webc:is="template">
+				// only reprocess text nodes in a <* webc:is="template" webc:type>
 				if(node.parentNode && this.getTagName(node.parentNode) === "template") {
 					c = await this.compileString(c, slots, options);
 				}
@@ -1054,7 +1054,7 @@ class AstSerializer {
 			} else if(node.content) {
 				let c = await this.getContentForTemplate(node, slots, options);
 
-				if(transformTypes.length > 0) { // only reprocess <template webc:type>
+				if(transformTypes.length > 0) { // reprocess <template webc:type>
 					c = await this.compileString(c, slots, options);
 				}
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -788,6 +788,7 @@ class AstSerializer {
 		// Passes the AST back to `compileNode` which can handle the rest
 		let { html: renderFunctionHtml } = await this.compileNode(renderFunctionAst, slots, options, false);
 
+		// Note that asset buckets are passed through options
 		return renderFunctionHtml;
 	}
 

--- a/src/ast.js
+++ b/src/ast.js
@@ -770,17 +770,17 @@ class AstSerializer {
 	}
 
 	/**
-	 * Reprocesses content returned from <template> or <* webc:is="template"> text nodes as WebC.
+	 * Compiles (reprocesses, issue #33) content returned from <template> or <* webc:is="template"> text nodes as WebC.
 	 *
-	 * @param {String} content
+	 * @param {String} rawContent
 	 * @param {Slots} slots
 	 * @param {CompileOptions} options
 	 * @returns {Promise<string>}
 	 * @private
 	 */
-	async reprocessContent(content, slots, options) {
+	async compileString(rawContent, slots, options) {
 		// Constructs an AST out of the string returned from the render function
-		let renderFunctionAst = await WebC.getASTFromString(content);
+		let renderFunctionAst = await WebC.getASTFromString(rawContent);
 
 		// no further transforms
 		delete options.currentTransformTypes;
@@ -962,7 +962,7 @@ class AstSerializer {
 
 				// only reprocess text nodes in a <* webc:is="template">
 				if(node.parentNode && this.getTagName(node.parentNode) === "template") {
-					c = await this.reprocessContent(c, slots, options);
+					c = await this.compileString(c, slots, options);
 				}
 			}
 
@@ -1055,7 +1055,7 @@ class AstSerializer {
 				let c = await this.getContentForTemplate(node, slots, options);
 
 				if(transformTypes.length > 0) { // only reprocess <template webc:type>
-					c = await this.reprocessContent(c, slots, options);
+					c = await this.compileString(c, slots, options);
 				}
 
 				content += this.outputHtml(c, streamEnabled);

--- a/src/ast.js
+++ b/src/ast.js
@@ -13,6 +13,23 @@ import { Streams } from "./streams.js";
 import { escapeText } from "entities/lib/escape.js";
 import { nanoid } from "nanoid";
 
+/** @typedef {import('parse5/dist/tree-adapters/default').Node} Node */
+/** @typedef {import('parse5/dist/tree-adapters/default').Template} Template */
+/** @typedef {import('parse5/dist/tree-adapters/default').TextNode} TextNode */
+/** @typedef {{ [key: string]: Node | undefined, default?: Node | undefined }} Slots */
+/**
+ * @typedef {object} CompileOptions
+ * @property {boolean} rawMode
+ * @property {boolean} isSlottedContent
+ * @property {boolean} isMatchingSlotSource
+ * @property {string} closestParentComponent
+ * @property {string} closestParentUid
+ * @property {{ buckets: { [key: string]: Set<string> }, css: any, js: any }} assets
+ * @property {DepGraph<any>} components
+ * @property {{ uid: string }} [componentProps]
+ * @property {Array<"render" | "css:scoped">} [currentTransformTypes]
+ */
+
 class FileSystemCache {
 	constructor() {
 		this.contents = {};
@@ -685,6 +702,12 @@ class AstSerializer {
 
 	/**
 	 * Transforms text nodes which are JavaScript Render Functions (i.e. they belong to a `<script webc:type="render">`)
+	 *
+	 * @param {TextNode} node
+	 * @param {Slots} slots
+	 * @param {CompileOptions} options
+	 * @returns {Promise<string>}
+	 * @private
 	 */
 	async getContentForRenderFunction(node, slots, options) {
 		// Resolves the render function inside the text node
@@ -702,6 +725,13 @@ class AstSerializer {
 		return renderFunctionHtml;
 	}
 
+	/**
+	 * @param {Node} node
+	 * @param {Slots} slots
+	 * @param {CompileOptions} options
+	 * @returns {Promise<string>}
+	 * @private
+	 */
 	async getContentForSlot(node, slots, options) {
 		let slotName = this.getAttributeValue(node, "name") || "default";
 		if(slots[slotName] || slotName !== "default") {
@@ -724,6 +754,13 @@ class AstSerializer {
 		return slotFallbackHtml;
 	}
 
+	/**
+	 * @param {Template} node
+	 * @param {Slots} slots
+	 * @param {CompileOptions} options
+	 * @returns {Promise<string>}
+	 * @private
+	 */
 	async getContentForTemplate(node, slots, options) {
 		let templateOptions = Object.assign({}, options);
 		// Processes `<template webc:root>` as WebC (including slot resolution)

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1987,25 +1987,30 @@ test("Using template component with webc:root and slot *does* process slots (Iss
 
 test("Render function result is resolves components (reprocessing, issue #33)", async (t) => {
 	let component = new WebC();
+	component.setBundlerMode(true);
 	component.setInputPath("./test/stubs/render-child-component.webc");
 	component.defineComponents({ "text-link": "./test/stubs/components/text-link-slot.webc" });
 
-	let { html } = await component.compile();
+	let { html, css } = await component.compile();
 
 	t.is(html, `<h3>Title</h3>
-<a href="/project">Link text</a>`);
+<text-link><a href="/project">Link text</a>
+</text-link>`);
+	t.deepEqual(css, [`/* CSS */`]);
 });
 
 test("Transform result will resolves components (reprocessing, issue #33)", async (t) => {
 	let component = new WebC();
+	component.setBundlerMode(true);
 	component.setTransform("text-link-component", (content) => {
-		return `<text-link href="/project">Link text</text-link>`
+		return `<text-link @href="/project">Link text</text-link>`
 	});
 
 	component.setInputPath("./test/stubs/plaintext-transform.webc");
 	component.defineComponents({ "text-link": "./test/stubs/components/text-link-slot.webc" });
 
-	let { html } = await component.compile();
-
-	t.is(html, `<a href="/project">Link text</a>`);
+	let { html, css } = await component.compile();
+	t.is(html, `<text-link><a href="/project">Link text</a>
+</text-link>`);
+	t.deepEqual(css, [`/* CSS */`]);
 });

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1970,3 +1970,14 @@ test("Using template component with webc:root and slot *does* process slots (Iss
 	slots: { default: "Overridden content" },
 	expectedHtml: "Overridden content",
 });
+
+test("Render function result is resolves components", async (t) => {
+	let component = new WebC();
+	component.setInputPath("./test/stubs/render-child-component.webc");
+	component.defineComponents({ "text-link": "./test/stubs/components/text-link-slot.webc" });
+
+	let { html } = await component.compile();
+
+	t.is(html, `<h3>Title</h3>
+<a href="/project">Link text</a>`);
+});

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1985,7 +1985,7 @@ test("Using template component with webc:root and slot *does* process slots (Iss
 	expectedHtml: "Overridden content",
 });
 
-test("Render function result is resolves components", async (t) => {
+test("Render function result is resolves components (reprocessing, issue #33)", async (t) => {
 	let component = new WebC();
 	component.setInputPath("./test/stubs/render-child-component.webc");
 	component.defineComponents({ "text-link": "./test/stubs/components/text-link-slot.webc" });
@@ -1994,4 +1994,18 @@ test("Render function result is resolves components", async (t) => {
 
 	t.is(html, `<h3>Title</h3>
 <a href="/project">Link text</a>`);
+});
+
+test("Transform result will resolves components (reprocessing, issue #33)", async (t) => {
+	let component = new WebC();
+	component.setTransform("text-link-component", (content) => {
+		return `<text-link href="/project">Link text</text-link>`
+	});
+
+	component.setInputPath("./test/stubs/plaintext-transform.webc");
+	component.defineComponents({ "text-link": "./test/stubs/components/text-link-slot.webc" });
+
+	let { html } = await component.compile();
+
+	t.is(html, `<a href="/project">Link text</a>`);
 });

--- a/test/stubs/components/text-link-slot.webc
+++ b/test/stubs/components/text-link-slot.webc
@@ -1,0 +1,1 @@
+<a :href="this.href"><slot>Default link text</slot></a>

--- a/test/stubs/components/text-link-slot.webc
+++ b/test/stubs/components/text-link-slot.webc
@@ -1,1 +1,2 @@
 <a :href="this.href"><slot>Default link text</slot></a>
+<style>/* CSS */</style>

--- a/test/stubs/plaintext-transform.webc
+++ b/test/stubs/plaintext-transform.webc
@@ -1,0 +1,1 @@
+<template webc:type="text-link-component">Testing</template>

--- a/test/stubs/render-child-component.webc
+++ b/test/stubs/render-child-component.webc
@@ -1,0 +1,6 @@
+<script webc:type="render" webc:is="template">
+function() {
+	return `<h3>Title</h3>
+<text-link href="/project">Link text</text-link>`;
+}
+</script>

--- a/test/stubs/render-child-component.webc
+++ b/test/stubs/render-child-component.webc
@@ -1,6 +1,6 @@
 <script webc:type="render" webc:is="template">
 function() {
 	return `<h3>Title</h3>
-<text-link href="/project">Link text</text-link>`;
+<text-link @href="/project">Link text</text-link>`;
 }
 </script>


### PR DESCRIPTION
## Changes

Adds the ability to resolve components in render functions and generally processes render function results like any WebC component.

Resolves #33.

## Notes

- These changes make the `compileNode` method somewhat more convoluted. I'd like to see a switch-case style branching here to have an easier-to-follow processing of nodes, but that's of course well outside the scope of this PR or something I'd be comfortable implementing as it's the very definition of working on WebC's core functionality.
- I'm passing `false` for `compileNode`'s `streamEnabled` argument which I copied from `getContentForTemplate` and because it magically fixed some tests that were miraculously broken in the streaming tests, but I have no better reason for it, so this is perhaps something deserving of the label "needs to be refined".
- Having two branches of `compileNode` deal with (and manipulate) `options.currentTransformTypes` seems dirty. I did what I had to, but I think there should be a better way to express "Hey, process the contents of a `<script webc:type="render">`" and "Hey, process regular text nodes".