### PR TITLE
feat: allows omitting "this" keyword from variables in @html, dynamic attributes, and props

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -945,7 +945,6 @@ class AstSerializer {
 		let componentHasContent = null;
 		let htmlAttribute = this.getAttributeValue(node, AstSerializer.attrs.HTML);
 		if(htmlAttribute) {
-			let fn = ModuleScript.evaluateAsyncAttribute(htmlAttribute);
 			let context = Object.assign({}, this.helpers, options.componentProps, this.globalData);
 			let proxiedContext = new Proxy(context, {
 				get(target, propertyName) {
@@ -957,6 +956,9 @@ Check that '${propertyName}' is a valid attribute or property name, is present i
 				}
 			});
 
+			// Wraps attribute referring to an existing variable in `context` in `this["variable"]` to allow for using variables without the `this` keyword.
+			let attribute = htmlAttribute in context && (!htmlAttribute.startsWith('this[') || !htmlAttribute.startsWith('this.')) ? `this["${htmlAttribute}"]` : htmlAttribute;
+			let fn = ModuleScript.evaluateAsyncAttribute(attribute);
 			let htmlContent = await fn.call(proxiedContext);
 			if(typeof htmlContent !== "string") {
 				htmlContent = `${htmlContent}`;

--- a/src/attributeSerializer.js
+++ b/src/attributeSerializer.js
@@ -64,8 +64,10 @@ class AttributeSerializer {
 
 	static normalizeAttribute(name, value, data, globalData) {
 		if(name.startsWith(AstSerializer.prefixes.dynamic)) {
-			let fn = ModuleScript.evaluateAttribute(value);
+			// Wraps attribute referring to an existing variable in `context` in `this["variable"]` to allow for using variables without the `this` keyword.
 			let context = Object.assign({}, data, globalData);
+			let attribute = value in context && (!value.startsWith('this[') || !value.startsWith('this.')) ? `this["${value}"]` : value;
+			let fn = ModuleScript.evaluateAttribute(attribute);
 
 			return {
 				name: name.slice(1),

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1566,7 +1566,12 @@ test("Using props without “this”", async t => {
 	let { html, css, js, components } = await component.compile({
 		data: {
 			variable: "value",
-			3: "number key"
+			3: "number key",
+			nested: {
+				object: {
+					fn: () => 'Boo!',
+				},
+			},
 		}
 	});
 
@@ -1580,7 +1585,8 @@ test("Using props without “this”", async t => {
 <p key="value"></p>
 <p key="2"></p>
 <p key="number key"></p>
-<p key="test"></p>`);
+<p key="test"></p>
+<p key="Boo!"></p>`);
 });
 
 test("Using @html", async t => {

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1558,6 +1558,31 @@ test("Using props", async t => {
 	t.is(html, `<img src="my-src.png">`);
 });
 
+test("Using props without “this”", async t => {
+	let component = new WebC();
+
+	component.setInputPath("./test/stubs/props-no-this.webc");
+
+	let { html, css, js, components } = await component.compile({
+		data: {
+			variable: "value",
+			3: "number key"
+		}
+	});
+
+	t.deepEqual(js, []);
+	t.deepEqual(css, []);
+	t.deepEqual(components, [
+		"./test/stubs/props-no-this.webc",
+	]);
+
+	t.is(html, `<p key="value"></p>
+<p key="value"></p>
+<p key="2"></p>
+<p key="number key"></p>
+<p key="test"></p>`);
+});
+
 test("Using @html", async t => {
 	let component = new WebC();
 

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1592,6 +1592,31 @@ test("Using @html with undefined properties or helpers", async (t) => {
 	});
 });
 
+test("Using @html without “this”", async t => {
+	let component = new WebC();
+
+	component.setInputPath("./test/stubs/html-no-this.webc");
+
+	let { html, css, js, components } = await component.compile({
+		data: {
+			variable: "value",
+			3: "number key"
+		}
+	});
+
+	t.deepEqual(js, []);
+	t.deepEqual(css, []);
+	t.deepEqual(components, [
+		"./test/stubs/html-no-this.webc",
+	]);
+
+	t.is(html, `<p>value</p>
+<p>value</p>
+<p>2</p>
+<p>number key</p>
+<p>test</p>`);
+});
+
 test("Issue #3 slot inconsistency", async t => {
 	let component = new WebC();
 

--- a/test/stubs/html-no-this.webc
+++ b/test/stubs/html-no-this.webc
@@ -1,0 +1,5 @@
+<p @html="variable">variable (without this)</p>
+<p @html="this.variable">variable (with this)</p>
+<p @html="2">number literal (not in context)</p>
+<p @html="3">number literal (in context)</p>
+<p @html="process.env.NODE_ENV">you know people are gonna try it</p>

--- a/test/stubs/props-no-this.webc
+++ b/test/stubs/props-no-this.webc
@@ -1,0 +1,5 @@
+<p :key="variable"></p>
+<p :key="this.variable"></p>
+<p :key="2"></p>
+<p :key="3"></p>
+<p :key="process.env.NODE_ENV"></p>

--- a/test/stubs/props-no-this.webc
+++ b/test/stubs/props-no-this.webc
@@ -3,3 +3,4 @@
 <p :key="2"></p>
 <p :key="3"></p>
 <p :key="process.env.NODE_ENV"></p>
+<p :key="this.nested.object.fn()"></p>


### PR DESCRIPTION
## Changes

Allows omitting the `this` keyword when referencing variables in `@html`. Values of `@html` are now automatically wrapped with `this[""]` **if** it doesn't already reference `this` *and* the variable actually exists in the relevant context.

Allows omitting the `this` keyword when referencing variables in dynamic attributes and props. References like that are now automatically wrapped with `this[""]` **if** it doesn't already include `this` *and* the variable actually exists in the relevant context.

## Implementation details

- It's required to wrap variables using square bracket notation (e.g. `this["prop"]`) instead of dot property access (e.g. `this.prop`) because things like `this.3` aren't valid (and throw a `SyntaxError`).

## Motivation

This (!) is driven by my appreciation for the cleanliness of writing Vue.js components using Vue's composition API with script setup syntax which does away with the utter dominance of this this this in Vue.js components written in Options API style. It's also inspired by how Vue's `ref`s can be accessed inside templates without referencing their `value` property which is otherwise necessary in scripts. It's just nice.

**Most importantly, I think it's actually nice and desirable for WebC because it's even less clear whatever the heck `this` refers to when you write a component where you might not even have any JavaScript at all**.

(<del>There are other features where the same strategy could be useful (specifically dynamic attributes), so if this is desired, I reckon I could add support for that, too</del> <ins>I did it</ins>.)