### PR TITLE
Fix: dynamic attributes example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ Make any attribute into a dynamic attribute by prefixing it with a `:`. You have
 `components/avatar-image.webc`:
 
 ```html
-<img :src="src" :alt="this.alt" class="avatar-image">
+<img :src="this.src" :alt="this.alt" class="avatar-image">
 ```
 
 #### Properties (or Props)


### PR DESCRIPTION
The [dynamic attributes](https://github.com/11ty/webc#dynamic-attributes) example in the README causes an error `ReferenceError: src is not defined` because `this.` is missing from the `src` value.