### PR TITLE
fix: not falling back to default slot content correctly

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -685,8 +685,13 @@ class AstSerializer {
 
 	async getContentForSlot(node, slots, options) {
 		let slotName = this.getAttributeValue(node, "name") || "default";
-		if(slots[slotName] || slotName !== "default") {
-			let slotAst = slots[slotName];
+		let slotAst = slots[slotName];
+
+		if(
+			(typeof slotAst === "object" && slotAst.childNodes.length > 0) ||
+			(typeof slotAst !== "object" && slotAst) ||
+			slotName !== "default"
+		) {
 			if(typeof slotAst === "string") {
 				slotAst = await WebC.getASTFromString(slotAst);
 			}

--- a/src/ast.js
+++ b/src/ast.js
@@ -540,6 +540,7 @@ class AstSerializer {
 	getSlottedContentNodes(node) {
 		let slots = {};
 		let defaultSlot = [];
+
 		// Slot definitions must be top level (this matches browser-based Web Components behavior)
 		for(let child of node.childNodes) {
 			let slotName = this.getAttributeValue(child, "slot");
@@ -549,6 +550,7 @@ class AstSerializer {
 				defaultSlot.push(child);
 			}
 		}
+
 		// faking a real AST by returning an object with childNodes
 		slots.default = { childNodes: defaultSlot };
 
@@ -688,8 +690,8 @@ class AstSerializer {
 		let slotAst = slots[slotName];
 
 		if(
-			(typeof slotAst === "object" && slotAst.childNodes.length > 0) ||
-			(typeof slotAst !== "object" && slotAst) ||
+			(typeof slotAst === "object" && slotAst.childNodes?.length > 0) || // might be a childNodes: []
+			(typeof slotAst !== "object" && slotAst) || // might be a string
 			slotName !== "default"
 		) {
 			if(typeof slotAst === "string") {

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -479,6 +479,20 @@ for(let filename in slotsStubs) {
 	});
 }
 
+test("Component falling back to default slot content (Issue #37)", async t => {
+	let component = new WebC();
+
+	component.setContent(`<web-component></web-component>`);
+
+	let {html} = await component.compile({
+		components: {
+			"web-component": "./test/stubs/slot-fallback-content.webc",
+		},
+	});
+
+	t.is(html, `<div>Fallback content</div>`);
+});
+
 test("<slot webc:raw>", async t => {
 	let component = new WebC();
 


### PR DESCRIPTION
Fixes a bug where rendering a component without child nodes wouldn't render that component's default slot content.

Fixes #37.