### PR TITLE
chore: caches node modules in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,13 @@
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+env:
+  YARN_GPG: no
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -9,12 +18,19 @@ jobs:
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup node
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-          # cache: npm
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package.json') }}
+
       - run: npm install
+
       - run: npm test
-env:
-  YARN_GPG: no


### PR DESCRIPTION
## Changes

Adds logic for caching the contents of the node_modules directory which speeds up workflow runs as long as the package.json file doesn't change (if the lock file is committed, it should be used to generate the caching key instead of the package.json file).

Adds pull requests as workflow triggers so people's contributions have tests running for them (for first-time contributors, a project maintainer must approve workflows to run, see https://github.blog/changelog/2021-04-22-github-actions-maintainers-must-approve-first-time-contributor-workflow-runs/; perhaps it's also possible to configure a repository so that this kind of approval is always required for branches on forks (origin repository branches would be fine because you would need push access anyway)).

## Notes

* Maybe the `YARN_GPG` isn't needed? This seems like a leftover from setting this up.