### PR TITLE
fix: add paths to module for require to work with node_modules

### DIFF
--- a/src/moduleScript.js
+++ b/src/moduleScript.js
@@ -1,4 +1,4 @@
-import { Module } from "module";
+import { Module, createRequire } from "module";
 import vm from "vm";
 
 class ModuleScript {
@@ -44,7 +44,8 @@ Original error message: ${e.message}`);
 	// TODO use the `vm` approach from `evaluateAttribute` above.
 	static getModule(content, filePath) {
 		let m = new Module();
-		// m.paths = module.paths;
+    const require = createRequire(import.meta.url);
+		m.paths = require.main.paths;
 		let trimmed = content.trim();
 
 		// replace `export default` with `module.exports`


### PR DESCRIPTION
This was otherwise preventing the usage of `require('my-npm-package')` in Eleventy JavaScript render templates.

A working example: https://github.com/RobinCsl/11ty-webc-img-demo/tree/rcsl/use-require/03-final

I didn't test what this might break or not as I'm not familiar with the codebase and cannot appreciate the consequences of these changes, other than it helps with my specific use-case!

Hope that's helpful!