### PR TITLE
fix: no end tag on void elements

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -1143,7 +1143,7 @@ class AstSerializer {
 		// Skip out early if the component has no content (not even whitespace)
 		// TODO possible improvement to use `hasTextContent` to ignore whitespace only children
 		//      Would we ever want to use webc:raw to output just whitespace?
-		if(start.endLine === end.startLine && start.endCol === end.startCol) {
+		if(!end || (start.endLine === end.startLine && start.endCol === end.startCol)) {
 			return "";
 		}
 


### PR DESCRIPTION
Fixes #67 by checking if the end tag exists and exiting early if it does not, preventing attempts to access properties of undefined.

Could alternatively use the `isVoidElement` helper method perhaps.