### PR TITLE
Add `webc:is="template"` to `webc:type="js"`(and `render`) docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,7 +507,7 @@ Run any arbitrary server JavaScript in WebC. Outputs the result of the very last
 `components/img.webc`:
 
 ```html
-<script webc:type="js">
+<script webc:type="js" webc:is="template">
 if(!alt) {
 	throw new Error("oh no you didn’t");
 }
@@ -519,7 +519,7 @@ if(!alt) {
 <summary>Expand to see this example with <code>webc:type="render"</code></summary>
 
 ```html
-<script webc:type="render">
+<script webc:type="render" webc:is="template">
 	function() {
 		if(!this.alt) {
 			throw new Error("oh no you didn’t");
@@ -568,7 +568,7 @@ function() {
 Here’s another example of a more complex conditional (you can also use `webc:if`!):
 
 ```html
-<script webc:type="js">
+<script webc:type="js" webc:is="template">
 if(alt) {
 	`<img src="${src}" alt="${alt}">`
 } else {


### PR DESCRIPTION
### Issue with the current README.md
`img.webc` in README, doesn't actually render the returned string in the `webc:type="js"` and `webc:type="render"` script blocks. Since it is missing `webc:is="template"`
```diff
- <script webc:type="js">
+ <script webc:type="js" webc:is="template">
```

Figured this out after looking at [`examples/render/components/img.webc`](https://github.com/11ty/webc/blob/main/examples/render/components/img.webc) (Thanks to @manekinekko)

### Is this really required?
The syntax in the current docs which is not working, actually looks intuitive.

Just like we aren't adding an extra `template` for normal HTML, we shouldn't need to specify `webc:is="template"` for the render scripts.

Thoughts?
