### PR TITLE
Support scoped prefixing for :host() and :host-context() pseudo classes

### DIFF
--- a/test/cssTest.js
+++ b/test/cssTest.js
@@ -69,11 +69,25 @@ test("Pseudo classes", t => {
 	t.is(c.process(`:host:not(p) div {}`), `.my-prefix:not(p) div{}`);
 	t.is(c.process(`:host.footer div {}`), `.my-prefix.footer div{}`); // same as :host(.footer)
 
-	// TODO :host(.footer) should be `.my-prefix.footer` but we can use `:host.footer` for now
-	t.is(c.process(`:host(.footer) div {}`), `.my-prefix div{}`);
+	t.is(c.process(`:host(.footer) div {}`), `.my-prefix.footer div{}`);
+	t.is(
+		c.process(`:host(.footer:not([lang])) .link {}`),
+		`.my-prefix.footer:not([lang]) .link{}`
+	);
+	t.is(
+		c.process(`:host(:is(div, span)) {}`),
+		`.my-prefix:is(div,span){}`
+	);
 
-	// TODO host-context(html body) should be `html body .my-prefix`
-	t.is(c.process(`:host-context(html) div {}`), `:host-context(html) div{}`);
+	t.is(c.process(`:host-context(html) div {}`), `html .my-prefix div{}`);
+	t.is(
+		c.process(`:host-context(html body.dark-theme) div {}`),
+		`html body.dark-theme .my-prefix div{}`
+	);
+	t.is(
+		c.process(`:host-context(html body:is(.dark-theme, .light-theme)) div {}`),
+		`html body:is(.dark-theme,.light-theme) .my-prefix div{}`
+	);
 });
 
 test("Pseudo elements", t => {


### PR DESCRIPTION
I've been working on building a site with webc and ran into a point where I was really wishing that the `:host-context()` pseudo-class worked for scoped styles. I saw there were some TODO comments regarding that, so I went ahead and took a stab at getting both `:host()` and `:host-context()` working.

Let me know if I misinterpreted anything, but this was my understanding of how they should work:
- `:host(.class) {}` -> `.prefix-class.class {}`
- `:host-context(.class) {}` -> `.class .prefix-class {}`

I added some more test cases to thoroughly cover this new functionality and everything seems like it's looking good, but let me know if anything seems off-base!