### PR TITLE
fix: Use consistent language in `AttributeSerializer` error message

### DIFF
--- a/src/attributeSerializer.js
+++ b/src/attributeSerializer.js
@@ -157,7 +157,7 @@ class AttributeSerializer {
 		let {name, evaluation, privacy} = AttributeSerializer.peekAttribute(rawName);
 		let evaluatedValue = value;
 		if(evaluation === "script") {
-			let { returns } = await ModuleScript.evaluateScriptInline(value, data, `Evaluating a dynamic attribute failed: \`${rawName}="${value}"\`.`, scriptContextKey);
+			let { returns } = await ModuleScript.evaluateScriptInline(value, data, `Evaluating a dynamic ${rawName.startsWith(AttributeSerializer.prefixes.dynamicProp) ? 'prop' : 'attribute' } failed: \`${rawName}="${value}"\`.`, scriptContextKey);
 			evaluatedValue = returns;
 		}
 
@@ -181,7 +181,7 @@ class AttributeSerializer {
 				let entry = {};
 				entry.rawName = rawName;
 				entry.rawValue = rawValue;
-	
+
 				entry.name = name;
 				entry.value = value;
 				entry.privacy = privacy;

--- a/test/parserTest.js
+++ b/test/parserTest.js
@@ -1834,6 +1834,16 @@ Original error message: helper is not a function`
 	});
 });
 
+test("Try to use a missing helper function in a dynamic prop (without this)", async (t) => {
+	let component = new WebC();
+	component.setContent(`<template :@key="helper()"></template>`);
+
+	await t.throwsAsync(component.compile(), {
+		message: `Evaluating a dynamic prop failed: \`:@key="helper()"\`.
+Original error message: helper is not a function`
+	});
+});
+
 
 test("Issue #3 slot inconsistency", async t => {
 	let component = new WebC();


### PR DESCRIPTION
I’m still learning WebC, so I did something wrong while trying to convert one of my projects. :)  

However, I noticed that the error message said the following:

```
Original error stack trace: Error: Evaluating a dynamic attribute failed: `:@text="data.x"`.
```

According to the docs, a dynamic _attribute_ has just the `:` prefix, but a dynamic _property_ (“_prop_”) has the `:@` prefix.

Since my error was caused by a dynamic prop, I thought I would make the error message use language that matches.

I also added a simple test to verify that the different error message is applied when appropriate.