### PR TITLE
Create new component manager per page

### DIFF
--- a/webc.js
+++ b/webc.js
@@ -222,7 +222,7 @@ class WebC {
 		let rawAst = this.getAST(content);
 
 		let ast = new AstSerializer(this.astOptions);
-		ast.setComponentManager(this.globalComponentManager);
+		ast.setComponentManager(new ComponentManager());
 		ast.setBundlerMode(this.bundlerMode);
 		ast.setMode(mode);
 		ast.setContent(content);


### PR DESCRIPTION
Create new component manager per page so webc:setup blocks get appropriate per-page contexts

Fixes #174 