### PR TITLE
Fixed hyphenated values not working bug.

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -784,6 +784,11 @@ class AstSerializer {
 		let ancestorComponent = this.getAuthoredInComponent(options);
 		let useGlobalData = this.useGlobalDataAtTopLevel(ancestorComponent);
 		let data = this.dataCascade.getData(useGlobalData, options.componentProps, ancestorComponent?.setupScript, options.injectedData);
+		for (const attrName in options.hostComponentData) {
+			if (!attrName.includes(AttributeSerializer.DASH)) continue;
+			if (!attrContent.includes(attrName)) continue;
+			attrContent = attrContent.replaceAll(attrName, AttributeSerializer.camelCaseAttributeName(attrName));
+		  }
 		let { returns } = await ModuleScript.evaluateScriptInline(attrContent, data, `Check the dynamic attribute: \`${name}="${attrContent}"\`.`, options.closestParentComponent);
 
 		return returns;

--- a/src/attributeSerializer.js
+++ b/src/attributeSerializer.js
@@ -8,6 +8,8 @@ class AttributeSerializer {
 		dynamicProp: ":@",
 	}
 
+	static DASH = "-";
+
 	// Merge multiple style/class attributes into a single one, operates on :dynamic and @prop but with transformed values
 	// Usage by: `getString` function when writing attributes to the HTML tag output
 	// Usage by: when generating data object for render functions
@@ -72,9 +74,8 @@ class AttributeSerializer {
 
 	// Inputs are guaranteed to be lower case (per the HTML specification)
 	static camelCaseAttributeName(name) {
-		const DASH = "-";
-		if(name.includes(DASH)) {
-			return name.split(DASH).map((entry, j) => {
+		if(name.includes(this.DASH)) {
+			return name.split(this.DASH).map((entry, j) => {
 				if(j === 0) {
 					return entry;
 				}


### PR DESCRIPTION
 Attributes and properties with hyphens where not being evaluated correctly in @html, @raw, @text, @attributes, webc:if, webc:elseif, and webc:for.  For example <div @text="my-attribute"></div> was not working at all. So I made sure that attribute content contained the correct camel case attribute names. Also exposed DASH as a static property in AttributeSerializer.